### PR TITLE
fix: comment repository option

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -96,11 +96,11 @@ gras:
     #           type: string
     #         creditLimit:
     #           type: number
-    repositories:
-      - name: classicmodelsid
-        spec:
-          datasource: classicmodelsid
-          model: clients
+    # repositories:
+    #   - name: classicmodelsid
+    #     spec:
+    #       datasource: classicmodelsid
+    #       model: clients
     # relations:
     #   - name: "employees"
     #     spec:


### PR DESCRIPTION
This causes a bug while starting the container as the `clients` model won't exist. It is disabled (by commenting out) a few lines above.